### PR TITLE
Add travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+sudo: true
+node_js:
+  - 10
+cache:
+  - npm
+jobs:
+  include:
+    - stage: Test
+      script: npm install
+      script: npm test


### PR DESCRIPTION
As part of the Google Code-in 2019 task "Add TravisCI support", I have created a `.travis.yml` file in the repository's root directory.

The file makes use of the npm test script defined in `package.json`.